### PR TITLE
use ILGeneration

### DIFF
--- a/StrictEmit/StrictEmit.csproj
+++ b/StrictEmit/StrictEmit.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="all" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="all" />
     <PackageReference Include="JetBrainsAnnotations.Fody" Version="2.2.0" PrivateAssets="all" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
   </ItemGroup>
   <Import Project="..\msbuild\netfx-mono.props" />
 </Project>


### PR DESCRIPTION
use the `System.Reflection.Emit.ILGeneration` package over the `System.Reflection.Emit` package to lessen the dependency bloat